### PR TITLE
Disable chart button if not Grepify scan

### DIFF
--- a/Win.CodeNavi/Win.CodeNavi/frmMain.cs
+++ b/Win.CodeNavi/Win.CodeNavi/frmMain.cs
@@ -1230,7 +1230,7 @@ namespace Win.CodeNavi
             // Now do the scan
 
             // Now initalize a search (aka results) form
-            frmSearch frmSearch = new frmSearch("Grepify scan of " + txtCodePath.Text + " (Regex:True,Case:" + opCaseSearch.Checked + ",Ignore Test:" + optIgnoreTest.Checked + ",Ignore Comments:"+ optIgnoreComments.Checked+") - " + txtExt.Text, this);
+            frmSearch frmSearch = new frmSearch("Grepify scan of " + txtCodePath.Text + " (Regex:True,Case:" + opCaseSearch.Checked + ",Ignore Test:" + optIgnoreTest.Checked + ",Ignore Comments:"+ optIgnoreComments.Checked+") - " + txtExt.Text, this, true);
             frmSearch.AddRegexColumn(); // Adds the extra column
             frmSearch.MdiParent = this;
             frmSearch.Visible = true;

--- a/Win.CodeNavi/Win.CodeNavi/frmSearch.cs
+++ b/Win.CodeNavi/Win.CodeNavi/frmSearch.cs
@@ -25,12 +25,20 @@ namespace Win.CodeNavi
         private ListViewColumnSorter lvwColumnSorter;
         private frmMain frmMaster = null;
         private Scanner scanEngine = null;
+        private bool bIsGrepify = false;
 
-        public frmSearch(String strTerm, frmMain frmMaster)
+        public frmSearch(String strTerm, frmMain frmMaster, bool bGrepify=false)
         {
             InitializeComponent();
             this.Text = "Search Results - " + strTerm;
             this.frmMaster = frmMaster;
+            this.bIsGrepify = bGrepify;
+            if (bGrepify)
+            {
+                this.cmdGraphResults.Enabled = true;
+            } else {
+                this.cmdGraphResults.Enabled = false; // Don't let people even click the button if it's not a grepify scan
+            }
             
         }
 
@@ -342,9 +350,12 @@ namespace Win.CodeNavi
 
         private void cmdGraphResults_Click(object sender, EventArgs e)
         {
-            frmCharts thisChart = new frmCharts(this.lstResults);
-            thisChart.MdiParent = frmMaster;
-            thisChart.Show();
+            if (this.bIsGrepify)
+            {
+                frmCharts thisChart = new frmCharts(this.lstResults);
+                thisChart.MdiParent = frmMaster;
+                thisChart.Show();
+            }
         }
 
         private void cmdMark_Click(object sender, EventArgs e)


### PR DESCRIPTION
The chart button is currently enabled when 'normal' scans are performed.
If the scan is not a Grepify scan then the button is disabled.
